### PR TITLE
Better save menu

### DIFF
--- a/NiceUtil/NiceUtilApp.swift
+++ b/NiceUtil/NiceUtilApp.swift
@@ -332,7 +332,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         let appsToLaunch = workspace.apps
         print("DEBUG: Found \(appsToLaunch.count) apps to launch")
+        
+        var skippedAppBundleIdentifiers: Set<String> = []
 
+        // First launch all apps without activation
         for app in appsToLaunch {
             print("DEBUG: Attempting to launch: \(app.appPath) (originally from space \(app.spaceNumber))")
             guard let url = URL(string: app.appPath) else {
@@ -343,19 +346,56 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
             // This configuration ensures that a new window is opened if the app is already running.
             let configuration = NSWorkspace.OpenConfiguration()
-            configuration.activates = true
-            configuration.createsNewApplicationInstance = true
-
-            NSWorkspace.shared.open(url, configuration: configuration) { runningApp, error in
+            configuration.activates = false
+            
+            // Check if the app is already running
+            if let bundleIdentifier = Bundle(url: url)?.bundleIdentifier,
+               NSWorkspace.shared.runningApplications.contains(where: { $0.bundleIdentifier == bundleIdentifier }) {
+                print("DEBUG: App \(url.lastPathComponent) is already running. Skipping launch.")
+                skippedAppBundleIdentifiers.insert(bundleIdentifier)
+                continue // Skip to the next app in the loop
+            }
+            
+            NSWorkspace.shared.openApplication(at: url,
+                                             configuration: configuration) { running, error in
                 if let error = error {
-                    print("DEBUG: Failed to process \(url.lastPathComponent): \(error)")
+                    print("DEBUG: Failed to launch \(url.lastPathComponent): \(error.localizedDescription)")
                     failedApps.append(url.lastPathComponent)
                 } else {
                     print("DEBUG: Successfully processed \(url.lastPathComponent)")
                 }
             }
         }
-
+        
+        // Then activate them after a delay
+        if !appsToLaunch.isEmpty {
+            print("DEBUG: Scheduling activation after delay...")
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+                for app in appsToLaunch {
+                    guard let url = URL(string: app.appPath),
+                          let runningApp = NSWorkspace.shared.runningApplications.first(where: { $0.bundleURL == url })
+                    else {
+                        print("DEBUG: Could not find running app for \(app.appPath)")
+                        continue
+                    }
+                    
+                    if let bundleIdentifier = runningApp.bundleIdentifier, skippedAppBundleIdentifiers.contains(bundleIdentifier) {
+                        print("DEBUG: App \(url.lastPathComponent) was previously skipped. Not activating.")
+                        continue
+                    }
+                    
+                    print("DEBUG: Activating \(url.lastPathComponent)")
+                    if #available(macOS 14.0, *) {
+                        runningApp.activate()
+                    } else {
+                        runningApp.activate(options: [.activateIgnoringOtherApps])
+                    }
+                }
+            }
+        } else {
+            print("DEBUG: No apps to launch")
+        }
+        
         if !failedApps.isEmpty {
             DispatchQueue.main.async {
                 self.showErrorAlert(message: "Failed to launch: \(failedApps.joined(separator: ", "))")
@@ -403,24 +443,33 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         self.popover = popover
     }
 
-    @objc func saveWorkspace() { 
-        let saveView = SaveWorkspaceView(isPresented: .constant(true), onSave: { name in
-            self.pendingWorkspaceName = name
-            let visibleApps = self.getAppsForCurrentSpace()
-            if !visibleApps.isEmpty {
-                self.save(workspaceName: name, appURLs: visibleApps)
+    @objc func saveWorkspace() {
+        let visibleApps = self.getAppsForCurrentSpace()
+        
+        // Perform the potentially long-running task on a background thread
+        DispatchQueue.global(qos: .userInitiated).async {
+            // Dispatch back to the main thread to update the UI
+            DispatchQueue.main.async {
+                let saveView = SaveWorkspaceView(isPresented: .constant(true), preSelectedApps: visibleApps, onSave: { name, selectedApps in
+                    self.pendingWorkspaceName = name
+                    if !selectedApps.isEmpty {
+                self.save(workspaceName: name, appURLs: selectedApps)
                 self.pendingWorkspaceName = nil
             }
             self.popover?.performClose(nil)
         }, onCancel: {
-            self.popover?.performClose(nil)
-        })
+                    self.popover?.performClose(nil)
+                }, onAddAllRunningApps: {
+                    return self.getAllRunningApplications()
+                })
 
-        let popover = NSPopover()
-        popover.contentViewController = NSHostingController(rootView: saveView)
-        popover.behavior = .transient
-        popover.show(relativeTo: self.statusItem!.button!.bounds, of: self.statusItem!.button!, preferredEdge: .minY)
-        self.popover = popover
+                let popover = NSPopover()
+                popover.contentViewController = NSHostingController(rootView: saveView)
+                popover.behavior = .transient
+                popover.show(relativeTo: self.statusItem!.button!.bounds, of: self.statusItem!.button!, preferredEdge: .minY)
+                self.popover = popover
+            }
+        }
     }
 
     func loadWorkspaces() -> [Workspace] {
@@ -448,7 +497,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         return appDirectoryURL.appendingPathComponent("workspaces.json")
     }
 
-    func getRunningApplications() -> [URL] {
+    
+
+    func getAllRunningApplications() -> [URL] {
         let runningApps = NSWorkspace.shared.runningApplications
         
         // Filter for regular apps that the user can see and interact with

--- a/NiceUtil/SaveWorkspaceView.swift
+++ b/NiceUtil/SaveWorkspaceView.swift
@@ -1,31 +1,178 @@
 import SwiftUI
 import KeyboardShortcuts
+import UniformTypeIdentifiers
+
+struct AppDisplayInfo: Identifiable, Hashable {
+    let id = UUID()
+    let url: URL
+    let origin: String
+
+    static func == (lhs: AppDisplayInfo, rhs: AppDisplayInfo) -> Bool {
+        lhs.url == rhs.url
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(url)
+    }
+}
 
 struct SaveWorkspaceView: View {
     @Binding var isPresented: Bool
-    var onSave: (String) -> Void
+    var onSave: (String, [URL]) -> Void
     var onCancel: (() -> Void)? = nil
+    var onAddAllRunningApps: (() -> [URL])? = nil
+
     @State private var workspaceName = ""
+    @State private var selectedApps: Set<AppDisplayInfo>
+    @State private var searchQuery = ""
+    @State private var allAvailableApps: [AppDisplayInfo]
+    @State private var allInstalledApps: [AppDisplayInfo] = []
+
+    init(isPresented: Binding<Bool>, preSelectedApps: [URL], onSave: @escaping (String, [URL]) -> Void, onCancel: (() -> Void)? = nil, onAddAllRunningApps: (() -> [URL])? = nil) {
+        self._isPresented = isPresented
+        self.onSave = onSave
+        self.onCancel = onCancel
+        self.onAddAllRunningApps = onAddAllRunningApps
+
+        // Initialize allAvailableApps with preSelectedApps (from current space)
+        let preSelectedDisplayInfos = preSelectedApps.map { AppDisplayInfo(url: $0, origin: "from current space") }
+        self._allAvailableApps = State(initialValue: preSelectedDisplayInfos.sorted { $0.url.lastPathComponent.lowercased() < $1.url.lastPathComponent.lowercased() })
+
+        // Initialize selectedApps with preSelectedApps (from current space)
+        self._selectedApps = State(initialValue: Set(preSelectedDisplayInfos))
+    }
+
+    var filteredApps: [AppDisplayInfo] {
+        if searchQuery.isEmpty {
+            return allAvailableApps
+        } else {
+            return allInstalledApps.filter { $0.url.lastPathComponent.lowercased().contains(searchQuery.lowercased()) }
+        }
+    }
 
     var body: some View {
         VStack {
             Text("Save Current Workspace")
                 .font(.headline)
+
             TextField("Workspace Name", text: $workspaceName)
                 .textFieldStyle(RoundedBorderTextFieldStyle())
+                .padding(.bottom)
+
+            TextField("Search Applications (e.g., installed apps)", text: $searchQuery)
+                .textFieldStyle(RoundedBorderTextFieldStyle())
+                .padding(.bottom)
+                .onAppear {
+                    loadAllInstalledApplications()
+                }
+
+            List {
+                ForEach(filteredApps) { appInfo in
+                    if searchQuery.isEmpty {
+                        Toggle(isOn: Binding(
+                            get: { selectedApps.contains(appInfo) },
+                            set: { isSelected in
+                                if isSelected {
+                                    selectedApps.insert(appInfo)
+                                } else {
+                                    selectedApps.remove(appInfo)
+                                }
+                            }
+                        )) {
+                            HStack {
+                                Image(nsImage: NSWorkspace.shared.icon(forFile: appInfo.url.path))
+                                    .resizable()
+                                    .frame(width: 20, height: 20)
+                                Text("\(appInfo.url.lastPathComponent.replacingOccurrences(of: ".app", with: "")) (\(appInfo.origin))")
+                            }
+                        }
+                    } else {
+                        HStack {
+                            Image(nsImage: NSWorkspace.shared.icon(forFile: appInfo.url.path))
+                                .resizable()
+                                .frame(width: 20, height: 20)
+                            Text("\(appInfo.url.lastPathComponent.replacingOccurrences(of: ".app", with: "")) (\(appInfo.origin))")
+                            Spacer()
+                            Button(action: {
+                                if !allAvailableApps.contains(appInfo) {
+                                    allAvailableApps.append(appInfo)
+                                    allAvailableApps.sort { $0.url.lastPathComponent.lowercased() < $1.url.lastPathComponent.lowercased() }
+                                }
+                                selectedApps.insert(appInfo)
+                                searchQuery = ""
+                            }) {
+                                Image(systemName: "plus.circle.fill")
+                            }
+                            .buttonStyle(BorderlessButtonStyle())
+                        }
+                    }
+                }
+            }
+            .frame(minHeight: 150, maxHeight: 300)
+            .border(Color.gray, width: 0.5)
+            .padding(.bottom)
+
+            HStack {
+                Button("Add All Running Apps") {
+                    if let allRunning = onAddAllRunningApps?() {
+                        for url in allRunning {
+                            let newAppInfo = AppDisplayInfo(url: url, origin: "from all workspaces")
+                            if !allAvailableApps.contains(newAppInfo) {
+                                allAvailableApps.append(newAppInfo)
+                                selectedApps.insert(newAppInfo)
+                            }
+                        }
+                        allAvailableApps.sort { $0.url.lastPathComponent.lowercased() < $1.url.lastPathComponent.lowercased() }
+                    }
+                }
+            }
+            .padding(.bottom)
+
             HStack {
                 Button("Cancel") {
                     isPresented = false
                     onCancel?()
                 }
                 Button("Save") {
-                    onSave(workspaceName)
+                    onSave(workspaceName, Array(selectedApps).map { $0.url })
                     isPresented = false
                 }
-                .disabled(workspaceName.isEmpty)
+                .disabled(workspaceName.isEmpty || selectedApps.isEmpty)
             }
         }
         .padding()
-        .frame(width: 300)
+        .frame(width: 400)
+    }
+
+    private func loadAllInstalledApplications() {
+        var installedApps: Set<URL> = []
+        let fileManager = FileManager.default
+
+        let appDirs = [
+            "/Applications",
+            "/System/Applications",
+            "/System/Library/CoreServices",
+            ("~/Applications" as NSString).expandingTildeInPath
+        ]
+
+        for dir in appDirs {
+            let url = URL(fileURLWithPath: dir)
+            if let enumerator = fileManager.enumerator(at: url, includingPropertiesForKeys: [.isDirectoryKey], options: [.skipsHiddenFiles, .skipsPackageDescendants]) {
+                for case let fileURL as URL in enumerator {
+                    if fileURL.pathExtension == "app" {
+                        installedApps.insert(fileURL)
+                    }
+                }
+            }
+        }
+        
+        // Filter out NiceUtil itself
+        if let currentAppBundleIdentifier = Bundle.main.bundleIdentifier {
+            installedApps = Set(installedApps.filter { url in
+                Bundle(url: url)?.bundleIdentifier != currentAppBundleIdentifier
+            })
+        }
+
+        self.allInstalledApps = installedApps.map { AppDisplayInfo(url: $0, origin: "installed") }.sorted { $0.url.lastPathComponent.lowercased() < $1.url.lastPathComponent.lowercased() }
     }
 }


### PR DESCRIPTION
# Changes:
Improved save workspace menu to easily see what applications are to be added to a workspace config including:
1. Searching for all installed applications
2. Adding or removing applications to add
3. Adding all currently opened applications
4. By default it just gets the applications opened from the current space e.g. not counting windows that may have been moved there from another space
Example picture:
<img width="449" height="417" alt="Screenshot 2025-07-27 at 18 54 37" src="https://github.com/user-attachments/assets/3beed689-c011-431b-8275-287fcdd2ba3a" />

Also made it so that if an applications is already opened on the computer it will not open it again (Not sure if this is wanted behavior) 